### PR TITLE
Fix: Now specifies fast-safe-stringify proper version (1.1.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "fast-safe-stringify": "1.1.0",
+    "fast-safe-stringify": "^1.1.0",
     "hoek": "4.x.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "node": ">=4.0.0"
   },
   "dependencies": {
-    "fast-safe-stringify": "^1.1.0",
+    "fast-safe-stringify": "1.1.x",
     "hoek": "4.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #21 
(for  "caret ranges" see https://github.com/npm/node-semver#caret-ranges-123-025-004)

